### PR TITLE
Switch to musl for Linux releases.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,3 @@ rustflags = [
     # For Windows static msvcrt linking with no need for dll re-distribution.
     "-C", "target-feature=+crt-static"
 ]
-
-[unstable]
-bindeps = true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ orbs:
   rust: circleci/rust@1.6.0
 
 jobs:
-  test-and-package:
+  test:
     machine:
       image: ubuntu-2004:current
     resource_class: arm.medium
@@ -30,10 +30,24 @@ jobs:
           version: nightly
       - rust/format:
           nightly-toolchain: true
+      - rust/install
       - rust/clippy
       - rust/test
-      - rust/cargo-run:
-          package: --release -p package dist
+  package:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: arm.medium
+    steps:
+      - checkout
+      - run:
+          name: Package ptex
+          command: |
+            mkdir dist
+            docker run --rm \
+              -v $PWD:/code \
+              -w /code \
+              rust:1.65.0-alpine3.15 \
+                sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
       - persist_to_workspace:
           root: dist
           paths:
@@ -53,11 +67,16 @@ jobs:
 workflows:
   ci:
     jobs:
-      - test-and-package
+      - test
+      - package
   release:
     when: << pipeline.parameters.GHA_Action >>
     jobs:
-      - test-and-package:
+      - test:
+          filters:
+            tags:
+              only: /^v.*/
+      - package:
           filters:
             tags:
               only: /^v.*/
@@ -66,7 +85,8 @@ workflows:
             tags:
               only: /^v.*/
           requires:
-            - test-and-package
+            - test
+            - package
           context:
             - GITHUB_CREDS
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on: [push, pull_request]
 defaults:
   run:
     shell: bash
-env:
-  CARGO_TERM_COLOR: always
 concurrency:
   group: CI-${{ github.ref }}
   # Queue on all branches and tags, but only cancel overlapping PR burns.
@@ -27,10 +25,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check Formatting
-        run: cargo fmt --check --all
+        run: |
+          rustup toolchain add nightly -c rustfmt
+          cargo +nightly fmt --check --all
       - name: Lint
         run: cargo clippy --all
       - name: Unit Tests
         run: cargo test --all
       - name: Build & Package
-        run: cargo run --release -p package dist
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: cargo run -p package
+      - name: Build & Package
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          mkdir dist
+          docker run --rm \
+            -v $PWD:/code \
+            -w /code \
+            rust:1.65.0-alpine3.15 \
+              sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,17 @@ jobs:
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Package ptex ${{ needs.determine-tag.outputs.release-tag }} binary
-        run: cargo run --release -p package dist
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
+        run: cargo run -p package
+      - name: Package ptex ${{ needs.determine-tag.outputs.release-tag }} binary
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        run: |
+          mkdir dist
+          docker run --rm \
+            -v $PWD:/code \
+            -w /code \
+            rust:1.65.0-alpine3.15 \
+              sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
       - name: Prepare Changelog
         id: prepare-changelog
         uses: a-scie/actions/changelog@v1.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,15 @@
 # Release Notes
 
+## 0.2.0
+
+This release brings fully static binaries for Linux with zero runtime
+linkage by switching the Linux targets to use musl. As part of this
+switch, the Rust toolchain used is stabilized to stable / 1.65.0.
+
 ## 0.1.15
 
-This release completes as much static linking  as possible on Linux by
-bringing zlib into the fold.
+This release completes as much static linking as possible on Linux using
+gnu by bringing zlib into the fold.
 
 ## 0.1.14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,43 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "cmake"
@@ -119,6 +162,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +190,21 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -138,6 +217,28 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -182,10 +283,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl-probe"
@@ -217,11 +330,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "package"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
+ "clap",
  "proc-exit",
- "ptex",
  "sha2",
 ]
 
@@ -244,6 +363,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d778539881515d37cd91925d169f4a351120c5a1b44fce2b7c462b0d7f4ec6"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "ptex"
-version = "0.1.15"
+version = "0.2.0"
 dependencies = [
  "curl",
  "indicatif",
@@ -273,6 +416,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,7 +442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -341,6 +498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +512,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -408,6 +580,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,12 +600,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -433,10 +635,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -445,13 +659,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "ptex"
-version = "0.1.15"
+version = "0.2.0"
 edition = "2021"
 authors = [
   "John Sirois <john.sirois@gmail.com>",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@
 ### Version Bump and Changelog
 
 1. Bump the version in [`Cargo.toml`](Cargo.toml).
-2. Run `cargo run --release -p package .` to update [`Cargo.lock`](Cargo.lock) with the new version
+2. Run `cargo run -p package` to update [`Cargo.lock`](Cargo.lock) with the new version
    and as a sanity check on the state of the project.
 3. Update [`CHANGES.md`](CHANGES.md) with any changes that are likely to be useful to consumers.
 4. Open a PR with these changes and land it on https://github.com/a-scie/ptex main.

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "package"
-version = "0.1.1"
+version = "0.2.0"
 description = "Packages the ptex binary."
 authors = [
     "John Sirois <john.sirois@gmail.com>",
@@ -8,9 +8,7 @@ authors = [
 edition = "2021"
 publish = false
 
-[build-dependencies]
-ptex = { path="..", artifact="bin" }
-sha2 = "0.10"
-
 [dependencies]
+clap = { version = "4.0", features = ["derive"] }
 proc-exit = "2.0"
+sha2 = "0.10"

--- a/package/build.rs
+++ b/package/build.rs
@@ -1,50 +1,15 @@
 // Copyright 2022 Science project contributors.
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::env;
-use std::path::PathBuf;
-
-use sha2::{Digest, Sha256};
-
-const PTEX_BINARY: &str = "ptex";
+fn env(name: &str) -> Result<String, String> {
+    std::env::var(name).map_err(|e| format!("Expected {name} to be set for build script: {e}"))
+}
 
 fn main() -> Result<(), String> {
-    let bindep_env_var = format!("CARGO_BIN_FILE_PTEX_{PTEX_BINARY}");
-    let path: PathBuf = std::env::var_os(&bindep_env_var)
-        .ok_or_else(|| format!("The {bindep_env_var} environment variable was not set."))?
-        .into();
-
-    let dest = std::env::var("OUT_DIR")
-        .map(|path| {
-            PathBuf::from(path)
-                .join(format!(
-                    "{PTEX_BINARY}-{os}-{arch}",
-                    os = env::consts::OS,
-                    arch = env::consts::ARCH
-                ))
-                .with_extension(env::consts::EXE_EXTENSION)
-        })
-        .map_err(|e| format!("{e}"))?;
-    std::fs::copy(path, &dest).map_err(|e| {
-        format!(
-            "Error copying {PTEX_BINARY} build to {dest}: {e}",
-            dest = dest.display()
-        )
-    })?;
-    println!("cargo:rustc-env=SCIE_STRAP={}", dest.display());
-
-    let mut reader = std::fs::File::open(&dest).map_err(|e| {
-        format!(
-            "Failed to open {dest} for hashing: {e}",
-            dest = dest.display()
-        )
-    })?;
-    let mut hasher = Sha256::new();
-    std::io::copy(&mut reader, &mut hasher).map_err(|e| format!("Failed to digest stream: {e}"))?;
     println!(
-        "cargo:rustc-env=SCIE_SHA256={digest:x}",
-        digest = hasher.finalize()
+        "cargo:rustc-env=OUT_DIR={out_dir}",
+        out_dir = env("OUT_DIR")?
     );
-
+    println!("cargo:rustc-env=TARGET={target}", target = env("TARGET")?);
     Ok(())
 }

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -1,47 +1,160 @@
 // Copyright 2022 Science project contributors.
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::path::PathBuf;
+use std::env;
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-use proc_exit::{Code, ExitResult};
+use clap::Parser;
+use proc_exit::{Code, Exit, ExitResult};
+use sha2::{Digest, Sha256};
+
+const BINARY: &str = "ptex";
+
+#[cfg(target_family = "windows")]
+const PATHSEP: &str = ";";
+
+#[cfg(target_family = "unix")]
+const PATHSEP: &str = ":";
+
+fn execute(command: &mut Command) -> ExitResult {
+    let mut child = command
+        .spawn()
+        .map_err(|e| Code::FAILURE.with_message(format!("{e}")))?;
+    let exit_status = child.wait().map_err(|e| {
+        Code::FAILURE.with_message(format!(
+            "Failed to gather exit status of command: {command:?}: {e}"
+        ))
+    })?;
+    if !exit_status.success() {
+        return Err(Code::FAILURE.with_message(format!(
+            "Command {command:?} failed with exit code: {code:?}",
+            code = exit_status.code()
+        )));
+    }
+    Ok(())
+}
+
+fn path_as_str(path: &Path) -> Result<&str, Exit> {
+    path.to_str().ok_or_else(|| {
+        Code::FAILURE.with_message(format!("Failed to convert path {path:?} into a UTF-8 str."))
+    })
+}
+
+#[derive(Clone)]
+struct SpecifiedPath(PathBuf);
+
+impl SpecifiedPath {
+    fn new(path: &str) -> Self {
+        Self::from(path.to_string())
+    }
+}
+
+impl From<String> for SpecifiedPath {
+    fn from(path: String) -> Self {
+        SpecifiedPath(PathBuf::from(path))
+    }
+}
+
+impl Deref for SpecifiedPath {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for SpecifiedPath {
+    fn as_ref(&self) -> &Path {
+        self.0.as_path()
+    }
+}
+
+impl Display for SpecifiedPath {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.display())
+    }
+}
+
+#[derive(Parser)]
+#[command(about, version)]
+struct Args {
+    #[arg(long, help = "Override the default --target for this platform.")]
+    target: Option<String>,
+    #[arg(
+        help = "The destination directory for the ptex binary and checksum file.",
+        default_value_t = SpecifiedPath::new("dist")
+    )]
+    dest_dir: SpecifiedPath,
+}
 
 fn main() -> ExitResult {
-    if std::env::args().len() != 2 {
-        return Err(Code::FAILURE.with_message(
-            "Usage: cargo run -p package <dest dir>\n\
-            \n\
-            A destination directory for the packaged ptex executable is required.",
-        ));
-    }
-
-    let src: PathBuf = env!("SCIE_STRAP").into();
-    let dst_dir: PathBuf = std::env::args().nth(1).unwrap().into();
-    let dst = {
-        let file_name = src.file_name().ok_or_else(|| {
-            Code::FAILURE.with_message(format!(
-                "Expected {src} to end in a file name.",
-                src = src.display()
-            ))
-        })?;
-        let dst = dst_dir.join(file_name);
-        if dst.extension().is_none() {
-            dst.with_extension(std::env::consts::EXE_EXTENSION)
-        } else {
-            dst
-        }
-    };
-
-    if dst_dir.is_file() {
+    let args = Args::parse();
+    let dest_dir = args.dest_dir;
+    if dest_dir.is_file() {
         return Err(Code::FAILURE.with_message(format!(
             "The specified dest_dir of {} is a file. Not overwriting",
-            dst_dir.display()
+            dest_dir.display()
         )));
     }
 
-    std::fs::create_dir_all(&dst_dir).map_err(|e| {
+    let cargo = env!("CARGO");
+    let cargo_manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+    // N.B.: OUT_DIR and TARGET are not normally available under compilation, but our custom build
+    // script forwards them.
+    let out_dir = env!("OUT_DIR");
+    let target = args.target.unwrap_or_else(|| env!("TARGET").to_string());
+    // Just in case this target is not already installed.
+    execute(Command::new("rustup").args(["target", "add", &target]))?;
+
+    let workspace_root = PathBuf::from(cargo_manifest_dir).join("..");
+    let output_root = PathBuf::from(out_dir).join("dist");
+    let output_bin_dir = output_root.join("bin");
+    execute(
+        Command::new(cargo)
+            .args([
+                "install",
+                "--path",
+                path_as_str(&workspace_root)?,
+                "--target",
+                &target,
+                "--root",
+                path_as_str(&output_root)?,
+            ])
+            // N.B.: This just suppresses a warning about adding this bin dir to your PATH.
+            .env(
+                "PATH",
+                vec![output_bin_dir.to_str().unwrap(), env!("PATH")].join(PATHSEP),
+            ),
+    )?;
+
+    let src = output_bin_dir.join(BINARY);
+    let mut reader = std::fs::File::open(&src).map_err(|e| {
+        Code::FAILURE.with_message(format!(
+            "Failed to open {src} for hashing: {e}",
+            src = src.display()
+        ))
+    })?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut reader, &mut hasher)
+        .map_err(|e| Code::FAILURE.with_message(format!("Failed to digest stream: {e}")))?;
+    let digest = hasher.finalize();
+
+    let file_name = format!(
+        "{BINARY}-{os}-{arch}{exe}",
+        os = env::consts::OS,
+        arch = env::consts::ARCH,
+        exe = env::consts::EXE_SUFFIX
+    );
+    let dst = dest_dir.join(&file_name);
+
+    std::fs::create_dir_all(&dest_dir).map_err(|e| {
         Code::FAILURE.with_message(format!(
             "Failed to create dest_dir {dest_dir}: {e}",
-            dest_dir = dst_dir.display()
+            dest_dir = dest_dir.display()
         ))
     })?;
     std::fs::copy(&src, &dst).map_err(|e| {
@@ -52,29 +165,17 @@ fn main() -> ExitResult {
         ))
     })?;
 
-    let file_name_raw = dst.file_name().ok_or_else(|| {
-        Code::FAILURE.with_message(format!(
-            "Expected {dst} to end in a file name.",
-            dst = dst.display()
-        ))
-    })?;
-    let file_name = file_name_raw.to_os_string().into_string().map_err(|e| {
-        Code::FAILURE.with_message(format!(
-            "Failed to interpret ptex file name as a utf-8 string: {e:?}"
-        ))
-    })?;
     let fingerprint_file = dst.with_file_name(format!("{file_name}.sha256"));
-    std::fs::write(
-        &fingerprint_file,
-        format!("{hash} *{file_name}\n", hash = env!("SCIE_SHA256")),
-    )
-    .map_err(|e| {
+    std::fs::write(&fingerprint_file, format!("{digest:x} *{file_name}\n")).map_err(|e| {
         Code::FAILURE.with_message(format!(
             "Failed to write fingerprint file {fingerprint_file}: {e}",
             fingerprint_file = fingerprint_file.display()
         ))
     })?;
 
-    eprintln!("Wrote the ptex to {}", dst.display());
+    eprintln!(
+        "Wrote the {BINARY} (target: {target}) to {dst}",
+        dst = dst.display()
+    );
     Code::SUCCESS.ok()
 }

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -131,7 +131,9 @@ fn main() -> ExitResult {
             ),
     )?;
 
-    let src = output_bin_dir.join(BINARY);
+    let src = output_bin_dir
+        .join(BINARY)
+        .with_extension(env::consts::EXE_EXTENSION);
     let mut reader = std::fs::File::open(&src).map_err(|e| {
         Code::FAILURE.with_message(format!(
             "Failed to open {src} for hashing: {e}",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "1.65.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
This also stabilizes the Rust toolchain to stable / 1.65.0.

Fixes #15