### PR TITLE
Support for `-O|--remote-name` in direct URL mode.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.4.0
+
+This release adds support for saving fetched content to a file by
+specifying the `-O` or `--remote-name` option when in direct URL mode.
+The ptex version can also e queried with `-V` or `--version`.
+
 ## 0.3.0
 
 This release adds support for direct use by passing a single URL to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +251,15 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -351,6 +388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "ptex"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "curl",
@@ -411,6 +454,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
+ "url",
 ]
 
 [[package]]
@@ -420,6 +465,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -522,6 +585,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,10 +618,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
@@ -553,10 +651,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "ptex"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",
@@ -23,6 +23,7 @@ anyhow = "1.0"
 indicatif = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+url = "2.3"
 
 [dependencies.curl]
 version = "0.4"
@@ -39,3 +40,8 @@ features = [
 
 [dev-dependencies]
 sha2 = "0.10"
+tempfile = "3.3"
+
+[[test]]
+name = "cli"
+path = "tests/cli.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,11 @@ use std::env;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use curl::easy::{Easy2, Handler, NetRc, WriteError};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use serde::Deserialize;
+use url::Url;
 
 #[derive(Deserialize)]
 struct Config {
@@ -100,12 +101,13 @@ fn fetch<W: Write>(url: &str, output: W) -> Result<()> {
         .with_context(|| format!("Failed to fetch {url}"))
 }
 
-fn usage() -> Result<()> {
-    let current_exe = env::current_exe().context("Failed to determine current executable")?;
-    eprintln!(
+fn usage(exit_code: i32) -> ! {
+    println!(
         r#"Usage:
-    {current_exe} [lift manifest path] [file name]
-    {current_exe} [URL]
+    {bin_name} -V|--version
+    {bin_name} -h|--help
+    {bin_name} [lift manifest path] [file name]
+    {bin_name} (-O|--remote-name) [URL]
 
     The `ptex` binary is a statically compiled URL fetcher based on
     libcurl. It supports the HTTP protocol up through HTTP/2, the FTP
@@ -114,7 +116,15 @@ fn usage() -> Result<()> {
     exits with a non-zero status if there was a network or protocol
     error.
 
-{current_exe} [lift manifest path] [file name]
+{bin_name} -V|--version
+
+    Print the ptex version.
+
+{bin_name} -h|--help
+
+    Display this help.
+
+{bin_name} [lift manifest path] [file name]
 
     For use in a scie file source binding. The first argument is the
     path to the scie lift manifest and the second argument is the file
@@ -166,14 +176,17 @@ fn usage() -> Result<()> {
     See more documentation on scie packaging configuration here:
      https://github.com/a-scie/jump/blob/main/docs/packaging.md
 
-{current_exe} [URL]
+{bin_name} (-O|--remote-name) [URL]
 
     For use as a fully self-contained curl-like binary. The given URL is
-    fetched and the response is streamed to stdout.
+    fetched and the response is streamed to a file if -O or
+    --remote-name was specified and otherwise to stdout.
+
+    -O  Write output to a file named as the remote file
 "#,
-        current_exe = current_exe.display()
+        bin_name = env!("CARGO_BIN_NAME")
     );
-    Ok(())
+    std::process::exit(exit_code);
 }
 
 trait OrExit<T> {
@@ -192,37 +205,56 @@ impl<T> OrExit<T> for Result<T> {
     }
 }
 
+fn open_remote_filename(url: &str) -> Result<impl Write> {
+    let parsed_url = Url::parse(url)?;
+    let remote_path = PathBuf::from(parsed_url.path());
+    let remote_file_name = remote_path
+        .file_name()
+        .ok_or_else(|| anyhow!("Could not determine the remote file name of {url}"))?;
+    let local_path = env::current_dir()?.join(remote_file_name);
+    std::fs::File::create(&local_path).with_context(|| {
+        format!(
+            "Failed to open {local_path} for streaming {url} to.",
+            local_path = local_path.display()
+        )
+    })
+}
+
 fn main() {
-    if env::args().len() == 3 {
-        let lift_manifest_path = PathBuf::from(
-            env::args()
-                .nth(1)
-                .expect("We checked there were 3 args just above"),
-        );
-        let file_path = PathBuf::from(
-            env::args()
-                .nth(2)
-                .expect("We checked there were 3 args just above"),
-        );
+    let mut save_as_remote_name = false;
+    let mut args = vec![];
+    for arg in env::args().skip(1) {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                usage(0);
+            }
+            "-V" | "--version" => {
+                println!(env!("CARGO_PKG_VERSION"));
+                std::process::exit(0);
+            }
+            "-O" | "--remote-name" => save_as_remote_name = true,
+            _ => args.push(arg),
+        }
+    }
 
-        let lift_manifest = std::fs::File::open(&lift_manifest_path)
-            .with_context(|| {
-                format!(
-                    "ailed to open lift manifest at {lift_manifest}",
-                    lift_manifest = lift_manifest_path.display()
-                )
-            })
-            .or_exit();
-        fetch_manifest(&lift_manifest, &file_path, std::io::stdout()).or_exit()
-    } else if env::args().len() == 2 {
-        let url = env::args()
-            .nth(1)
-            .expect("We checked there were 2 args just above");
-
-        fetch(url.as_str(), std::io::stdout()).or_exit()
-    } else {
-        usage().or_exit();
-        std::process::exit(1);
+    match &args[..] {
+        [lift_manifest_path, file_path] if !save_as_remote_name => {
+            let lift_manifest = std::fs::File::open(lift_manifest_path)
+                .with_context(|| format!("Failed to open lift manifest at {lift_manifest_path}"))
+                .or_exit();
+            fetch_manifest(&lift_manifest, &PathBuf::from(file_path), std::io::stdout()).or_exit()
+        }
+        [url] => {
+            if save_as_remote_name {-
+                let file = open_remote_filename(url).or_exit();
+                fetch(url, file).or_exit();
+            } else {
+                fetch(url, std::io::stdout()).or_exit();
+            }
+        }
+        _ => {
+            usage(1);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,7 +245,7 @@ fn main() {
             fetch_manifest(&lift_manifest, &PathBuf::from(file_path), std::io::stdout()).or_exit()
         }
         [url] => {
-            if save_as_remote_name {-
+            if save_as_remote_name {
                 let file = open_remote_filename(url).or_exit();
                 fetch(url, file).or_exit();
             } else {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 Science project contributors.
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::process::{Command, Stdio};
+
+use sha2::{Digest, Sha256};
+
+const PTEX: &str = env!("CARGO_BIN_EXE_ptex");
+const URL: &str = "https://github.com/a-scie/jump/releases/download/v0.2.1/scie-jump-linux-aarch64";
+
+fn assert_fetched_buffer(buffer: &[u8]) {
+    assert_eq!(1205568, buffer.len());
+    assert_eq!(
+        "937683255e98caf10745a674d7063bd38e9cbeb523b9f8ef4dbe8807abc35382".to_string(),
+        format!("{digest:x}", digest = Sha256::digest(buffer))
+    );
+}
+
+#[test]
+fn version() {
+    assert_eq!(
+        env!("CARGO_PKG_VERSION"),
+        std::io::read_to_string(
+            Command::new(PTEX)
+                .arg("--version")
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .spawn()
+                .unwrap()
+                .stdout
+                .unwrap()
+        )
+        .unwrap()
+        .trim()
+    );
+}
+
+#[test]
+fn fetch_remote_name() {
+    let tempdir = tempfile::tempdir().unwrap();
+    assert!(Command::new(PTEX)
+        .args(["-O", URL])
+        .current_dir(&tempdir)
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap()
+        .success());
+    let local_file = tempdir.path().join("scie-jump-linux-aarch64");
+    assert!(local_file.is_file());
+    assert_fetched_buffer(std::fs::read(local_file).unwrap().as_slice());
+}


### PR DESCRIPTION
This follows curl CLI convention and will be used by the scie-pants
packaging program to avoid system dependencies and work easily on
Windows.