### PR TITLE
Upgrade to Rust 1.70.0.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[registries.crates-io]
-protocol = "sparse"
-
 [target.aarch64-pc-windows-msvc]
 rustflags = [
     # For Windows static msvcrt linking with no need for dll re-distribution.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             docker run --rm \
               -v $PWD:/code \
               -w /code \
-              rust:1.69.0-alpine3.17 \
+              rust:1.70.0-alpine3.18 \
                 sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
       - persist_to_workspace:
           root: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.69.0-alpine3.17 \
+            rust:1.70.0-alpine3.18 \
               sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.69.0-alpine3.17 \
+            rust:1.70.0-alpine3.18 \
               sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
       - name: Prepare Changelog
         id: prepare-changelog

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,6 +1,6 @@
 [toolchain]
 # N.B.: Update .github and .circleci yaml to use a matching image.
-channel = "1.69.0"
+channel = "1.70.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html

Since the sparse index protocol is now default, kill the explicit
configuration of that.

Closes #64