### PR TITLE
Upgrade to Rust 1.76.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
             docker run --rm \
               -v $PWD:/code \
               -w /code \
-              rust:1.75.0-alpine3.19 \
+              rust:1.76.0-alpine3.19 \
                 sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
       - persist_to_workspace:
           root: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.75.0-alpine3.19 \
+            rust:1.76.0-alpine3.19 \
               sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.75.0-alpine3.19 \
+            rust:1.76.0-alpine3.19 \
               sh -c 'apk add cmake make musl-dev perl && cargo run -p package -- dist'
       - name: Prepare Changelog
         id: prepare-changelog

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -2,7 +2,7 @@
 # N.B.: Update .github and .circleci yaml to use a matching image, if available.
 # Although a version match is not required (cargo downloads and installs the
 # toolchain described here if not present), it does speed up CI builds.
-channel = "1.75.0"
+channel = "1.76.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html