### PR TITLE
Upgrade from curl 8.0.1 to curl 8.6.0.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 0.7.1
+
+This release updates various dependencies, most notably updating from
+curl 8.0.1 (March 20, 2023) to 8.6.0 (January 31, 2024).
+See:
++ https://curl.se/changes.html
++ https://curl.se/docs/releases.html
++ https://curl.se/docs/vulnerabilities.html
+
 ## 0.7.0
 
 This release updates various dependencies, most notably updating from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+checksum = "f8e5123ab8c31200ce725939049ecd4a090b242608f24048131dedf9dd195aed"
 dependencies = [
  "curl-sys",
  "libc",
@@ -182,14 +182,14 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.61+curl-8.0.1"
+version = "0.4.72+curl-8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d05c10f541ae6f3bc5b3d923c20001f47db7d5f0b2bc6ad16490133842db79"
+checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
 dependencies = [
  "cc",
  "libc",
@@ -198,7 +198,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "ptex"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "curl",
@@ -508,12 +508,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -621,28 +621,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,8 +173,7 @@ dependencies = [
 [[package]]
 name = "curl"
 version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e5123ab8c31200ce725939049ecd4a090b242608f24048131dedf9dd195aed"
+source = "git+https://github.com/a-scie/curl-rust?rev=9f8c905174d1d3afa675d852f01818f76d21106e#9f8c905174d1d3afa675d852f01818f76d21106e"
 dependencies = [
  "curl-sys",
  "libc",
@@ -188,8 +187,7 @@ dependencies = [
 [[package]]
 name = "curl-sys"
 version = "0.4.72+curl-8.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
+source = "git+https://github.com/a-scie/curl-rust?rev=9f8c905174d1d3afa675d852f01818f76d21106e#9f8c905174d1d3afa675d852f01818f76d21106e"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "ptex"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ serde_json = "1.0"
 url = "2.5"
 
 [dependencies.curl]
+# TODO(John Sirois): XXX: Update with PR URL once CI goes green as proof of fix.
+git = "https://github.com/a-scie/curl-rust"
+rev = "9f8c905174d1d3afa675d852f01818f76d21106e"
+
 version = "0.4"
 default-features = false
 features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,10 @@ serde_json = "1.0"
 url = "2.5"
 
 [dependencies.curl]
-# TODO(John Sirois): XXX: Update with PR URL once CI goes green as proof of fix.
+# This is 0.4.45 with a patch to Cargo.toml to add a missing feature requirement on the windows-sys
+# crate.
+# TODO(John Sirois): Switch back to mainline when https://github.com/alexcrichton/curl-rust/pull/547
+# is resolved.
 git = "https://github.com/a-scie/curl-rust"
 rev = "9f8c905174d1d3afa675d852f01818f76d21106e"
 


### PR DESCRIPTION
This was prompted by a failed dependabot update of the curl crate which
also required a curl-sys update.

(`cargo update -p curl -p curl-sys`)