### PR TITLE
Upgrade actions.

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cargo audit (for security vulnerabilities)
         run: |
           cargo install --version 0.18.1 cargo-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-12, macos-13-aarch64, windows-2022]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check Formatting
         run: |
           rustup toolchain add nightly -c rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     environment: Release
     steps:
       - name: Checkout ptex ${{ needs.determine-tag.outputs.release-tag }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Package ptex ${{ needs.determine-tag.outputs.release-tag }} binary
@@ -72,7 +72,8 @@ jobs:
           version: ${{ needs.determine-tag.outputs.release-version }}
           setup-python: ${{ matrix.os != 'macos-13-aarch64' }}
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
-        uses: softprops/action-gh-release@v1
+        # Upgrades node16 -> node20: in main but not tagged yet.
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -92,7 +93,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Trigger aarch64 release
-        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        # Upgrade node16 -> node20: Out for review here:
+        #   https://github.com/CircleCI-Public/trigger-circleci-pipeline-action/pull/75
+        uses: a-scie/trigger-circleci-pipeline-action@5386b18a33d1d272a294422b78d35bd09256fb8f
         with:
           GHA_Meta: "${{ needs.determine-tag.outputs.release-tag }}"
         env:


### PR DESCRIPTION
This eliminates node16 warnings / prepares for the spring when node16
goes away.