### PR TITLE
Upgrade to Rust 1.84.1.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.84.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2025/01/30/Rust-1.84.1.html