### PR TITLE
Upgrade to Rust 1.85.0 / 2024 edition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "ptex"
 version = "1.5.1"
-edition = "2021"
+edition = "2024"
 authors = [
     "John Sirois <john.sirois@gmail.com>",
 ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = [
   "cargo",
   "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use curl::easy::{Easy2, Handler, List, NetRc, WriteError};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use serde::Deserialize;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -38,14 +38,16 @@ fn version() {
 #[test]
 fn fetch_remote_name() {
     let tempdir = tempfile::tempdir().unwrap();
-    assert!(Command::new(PTEX)
-        .args(["-O", URL])
-        .current_dir(&tempdir)
-        .spawn()
-        .unwrap()
-        .wait()
-        .unwrap()
-        .success());
+    assert!(
+        Command::new(PTEX)
+            .args(["-O", URL])
+            .current_dir(&tempdir)
+            .spawn()
+            .unwrap()
+            .wait()
+            .unwrap()
+            .success()
+    );
     let local_file = tempdir.path().join("scie-jump-linux-aarch64");
     assert!(local_file.is_file());
     assert_fetched_buffer(std::fs::read(local_file).unwrap().as_slice());


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html