### PR TITLE
Upgrade to Rust 1.85.1 (#281)

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.85.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2025/03/18/Rust-1.85.1.html