### PR TITLE
Add support for `-s` / `--silent`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 1.6.0
+
+This release adds support for `-s` / `--silent` to force fetch progress
+output to be hidden.
+
 ## 1.5.1
 
 This release updates various dependencies, most notably updating from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "ptex"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "ptex"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2024"
 authors = [
     "John Sirois <john.sirois@gmail.com>",


### PR DESCRIPTION
This mirrors curl and does not affect `-D`; it just shuts off progress
output to stderr.