### PR TITLE
Upgrade to Rust 1.88.0.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Release announcement: https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/