### PR TITLE
Upgrade Rust to 1.90.0.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/