### PR TITLE
Upgrade Rust to 1.94.1.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.94.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2026/03/26/1.94.1-release/