### PR TITLE
Upgrade to Rust 1.96.1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           - os: ubuntu-24.04
             name: Linux powerpc64le
             cross-target: powerpc64le-unknown-linux-gnu
-          - os: macos-x86_64
+          - os: macos-15-intel
             name: macOS x86-64
           - os: macos-14
             name: macOS aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           - os: ubuntu-24.04
             name: Linux s390x
             cross-target: s390x-unknown-linux-gnu
-          - os: macos-x86_64
+          - os: macos-15-intel
             name: macOS x86-64
           - os: macos-14
             name: macOS aarch64

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -149,7 +149,13 @@ fn main() -> ExitResult {
             .env(
                 "PATH",
                 [output_bin_dir.to_str().unwrap(), env!("PATH")].join(PATHSEP),
-            ),
+            )
+            // N.B.: This avoids a spurious warning of this sort:
+            // warning: default toolchain implicitly overridden with `1.96.0-x86_64-unknown-linux-gnu` by rustup toolchain file
+            //   |
+            //   = help: use `cargo +stable install` if you meant to use the stable toolchain
+            //   = note: rustup selects the toolchain based on the parent environment and not the environment of the package being installed
+            .env_remove("RUSTUP_TOOLCHAIN_SOURCE"),
     )?;
 
     let src = output_bin_dir

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.96.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/